### PR TITLE
Make it to work on GHC 8 as well

### DIFF
--- a/semver-range.cabal
+++ b/semver-range.cabal
@@ -28,7 +28,7 @@ library
                      , ScopedTypeVariables
                      , TypeFamilies
                      , TypeSynonymInstances
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && <5
                      , classy-prelude
                      , text
                      , unordered-containers


### PR DESCRIPTION
I adjusted Cabal package metadata to support the recent versions of `base` so that GHC 8 can build the package.
