### PR TITLE
Refactor nix infrastructure to use a pinned nixpkgs-17.09

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,17 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
-let
-  haskellPackages = nixpkgs.pkgs.haskell.packages.${compiler};
-in
-
-haskellPackages.callPackage ./project.nix {}
+{ mkDerivation, base, classy-prelude, hspec, parsec, QuickCheck
+, stdenv, text, unordered-containers
+}:
+mkDerivation {
+  pname = "semver-range";
+  version = "0.2.6";
+  src = ./.;
+  libraryHaskellDepends = [
+    base classy-prelude parsec text unordered-containers
+  ];
+  testHaskellDepends = [
+    base classy-prelude hspec parsec QuickCheck text
+    unordered-containers
+  ];
+  description = "An implementation of semver and semantic version ranges";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/17_09.nix
+++ b/nix/17_09.nix
@@ -1,0 +1,9 @@
+let
+  fetchNixpkgs = import ./fetchNixpkgs.nix;
+
+in
+  fetchNixpkgs {
+     rev          = "3389f23412877913b9d22a58dfb241684653d7e9";
+     sha256       = "1zf05a90d29bpl7j56y20r3kmrl4xkvg7gsfi55n6bb2r0xp2ma5";
+     outputSha256 = "0wgm7sk9fca38a50hrsqwz6q79z35gqgb9nw80xz7pfdr4jy9pf8";
+  }

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,49 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+, outputSha256 ? null             # The SHA256 output hash
+, system ? builtins.currentSystem # This is overridable if necessary
+}:
+
+if (0 <= builtins.compareVersions builtins.nixVersion "1.12")
+
+# In Nix 1.12, we can just give a `sha256` to `builtins.fetchTarball`.
+then (
+  builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    inherit sha256;
+  })
+
+# This hack should at least work for Nix 1.11
+else (
+  (rec {
+    tarball = import <nix/fetchurl.nix> {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    };
+
+    builtin-paths = import <nix/config.nix>;
+      
+    script = builtins.toFile "nixpkgs-unpacker" ''
+      "$coreutils/mkdir" "$out"
+      cd "$out"
+      "$gzip" --decompress < "$tarball" | "$tar" -x --strip-components=1
+    '';
+
+    nixpkgs = builtins.derivation ({
+      name = "nixpkgs-${builtins.substring 0 6 rev}";
+
+      builder = builtins.storePath builtin-paths.shell;
+
+      args = [ script ];
+
+      inherit tarball system;
+
+      tar       = builtins.storePath builtin-paths.tar;
+      gzip      = builtins.storePath builtin-paths.gzip;
+      coreutils = builtins.storePath builtin-paths.coreutils;
+    } // (if null == outputSha256 then { } else {
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+      outputHash = outputSha256;
+    }));
+  }).nixpkgs)

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,22 @@
+{ nixpkgs ? (import ./nix/17_09.nix) }:
+
+let
+
+  config   = { allowUnfree = true; };
+
+  overlays = [
+    (newPkgs: oldPkgs: {
+      haskellPackages = oldPkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: {
+          semver-range = 
+            haskellPackagesNew.callPackage ./default.nix { };
+        };
+      };
+    })
+  ];
+
+  pkgs = import nixpkgs { inherit config overlays; };
+
+in
+
+  { inherit (pkgs.haskellPackages) semver-range; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,1 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
-(import ./default.nix { inherit nixpkgs compiler; }).env
+args@{...}: (import ./release.nix args).semver-range.env


### PR DESCRIPTION
Motivated by the desire to build against a pin instead of my (less stable) ambient `nixpkgs`. We also introduce the `release.nix` convention and make the `default.nix` the cabal2nix generated code so that any overrides for building can be done in the `release.nix` integration point.