### PR TITLE
Support building with GHC 8.4 on macOS Mojave

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "semver-range";
-  version = "0.2.6";
+  version = "0.2.7";
   src = ./.;
   libraryHaskellDepends = [
     base classy-prelude parsec text unordered-containers

--- a/nix/17_09.nix
+++ b/nix/17_09.nix
@@ -1,8 +1,0 @@
-let
-  fetchNixpkgs = import ./fetchNixpkgs.nix;
-
-in
-  fetchNixpkgs {
-     rev          = "e1ad1a0aa2ce6f9fd951d18181ba850ca8e74133";
-     sha256       = "0vk5sjmbq52xfrinrhvqry53asl6ppwbly1l7ymj8g0j4pkjf7p1";
-  }

--- a/nix/17_09.nix
+++ b/nix/17_09.nix
@@ -3,7 +3,6 @@ let
 
 in
   fetchNixpkgs {
-     rev          = "3389f23412877913b9d22a58dfb241684653d7e9";
-     sha256       = "1zf05a90d29bpl7j56y20r3kmrl4xkvg7gsfi55n6bb2r0xp2ma5";
-     outputSha256 = "0wgm7sk9fca38a50hrsqwz6q79z35gqgb9nw80xz7pfdr4jy9pf8";
+     rev          = "e1ad1a0aa2ce6f9fd951d18181ba850ca8e74133";
+     sha256       = "0vk5sjmbq52xfrinrhvqry53asl6ppwbly1l7ymj8g0j4pkjf7p1";
   }

--- a/nix/18_09.nix
+++ b/nix/18_09.nix
@@ -1,0 +1,8 @@
+let
+  fetchNixpkgs = import ./fetchNixpkgs.nix;
+
+in
+  fetchNixpkgs {
+     rev          = "6a3f5bcb061e1822f50e299f5616a0731636e4e7";
+     sha256       = "1ib96has10v5nr6bzf7v8kw7yzww8zanxgw2qi1ll1sbv6kj6zpd";
+  }

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? (import ./nix/17_09.nix) }:
+{ nixpkgs ? (import ./nix/18_09.nix) }:
 
 let
 

--- a/src/Data/SemVer/Types.hs
+++ b/src/Data/SemVer/Types.hs
@@ -33,7 +33,7 @@ instance IsString PrereleaseTag where
 instance Hashable PrereleaseTag
 
 newtype PrereleaseTags = PrereleaseTags [PrereleaseTag]
-  deriving (Show, Eq, Monoid, Generic)
+  deriving (Show, Eq, Semigroup, Monoid, Generic)
 
 instance IsList PrereleaseTags where
   type Item PrereleaseTags = PrereleaseTag


### PR DESCRIPTION
This adds a Semigroup instance to support building with GHC 8.4

It includes some other changes, which I'll call out.